### PR TITLE
Added pocket bike lane

### DIFF
--- a/schema/Lanes.yml
+++ b/schema/Lanes.yml
@@ -195,6 +195,16 @@ features:
     - sharrows=left/right/both
   mapillary: d-l1qlsZsdb1vJWyeIVeDw
 
+- feature: Pocket bike lane
+  description: |
+    Painted lane positioned between a right-turn lane and a
+    through lane.
+  elements:
+    - way
+  osm:
+    -
+  mapillary: bDPf-6VzTi52JG2JqqNkjg
+
 - feature: Traffic-calming parking lane
   description: |
     Resembles a bike lane or paved shoulder,


### PR DESCRIPTION
I'm not sure if this should be treated any differently from a regular bike lane from a tagging point of view.  The MTI cycling stress analysis document analyzes it separately (http://transweb.sjsu.edu/PDFs/research/1005-low-stress-bicycling-network-connectivity.pdf See page 23) and it would be helpful to be able to detect this situation through the tags. 