### PR TITLE
Paved MUP - highway not cycleway

### DIFF
--- a/schema/Lanes.yml
+++ b/schema/Lanes.yml
@@ -6,8 +6,9 @@ features:
   elements:
     - way
   osm:
-    - highway=cycleway
-    - foot=yes
+    - highway=path
+    - width=*
+    - smoothness=*
     - segregated=no
     - surface=asphalt
   mapillary: xvX6Bexu1gEE_H9KlfodLQ


### PR DESCRIPTION
This was discussed earlier. Either could be used, but cycleways tend to be reserved for bikes, so you'd always have to be adding foot=yes. Also, the major paths in the Ottawa area are already tagged as highway=path.