### PR TITLE
advisory bike lane = cyclestreet

### DIFF
--- a/schema/Lanes.yml
+++ b/schema/Lanes.yml
@@ -146,7 +146,7 @@ features:
   elements:
     - way
   osm:
-    -
+    - cycleway=cyclestreet
   mapillary: ok7p-w_Ej9nIG-S9eKK8pg
 
 - feature: Shared bus/bike lane


### PR DESCRIPTION
little to no wiki documentation available. https://help.openstreetmap.org/questions/39500/dutch-cycle-paths-with-cars-as-guests Much like how we handled the shared busway, cycleway=share_busway, to say cycleway=cyclestreet seemed most appropriate