### PR TITLE
Update Parking.yml

### DIFF
--- a/schema/Parking.yml
+++ b/schema/Parking.yml
@@ -9,7 +9,7 @@ features:
   elements:
     - way
   osm:
-    - parking:lane:left=yes
+    - parking:lane:left=parallel
   mapillary:
 
 - feature: Right
@@ -18,7 +18,7 @@ features:
   elements:
     - way
   osm:
-    - parking:lane:right=yes
+    - parking:lane:right=parallel
   mapillary:
 
 - feature: Both
@@ -27,7 +27,7 @@ features:
   elements:
     - way
   osm:
-    - parking:lane=yes
+    - parking:lane:both=parallel
   mapillary:
 
 - feature: No Parking
@@ -36,7 +36,7 @@ features:
   elements:
     - way
   osm:
-    - parking:lane=no_parking
+    - parking:lane:both=no_parking
   mapillary:
 
 - feature: No Stopping
@@ -45,5 +45,5 @@ features:
   elements:
     - way
   osm:
-    - parking:lane=no_stopping
+    - parking:lane:both=no_stopping
   mapillary:


### PR DESCRIPTION
Was looking at the parking OSM scheme and it looks like `parking:lane:both`=`parallel` is the proper tag instead of `parking:lane`=`yes` or `parking:lane:both`=`yes`.

FYI: I've updated all the existing `parking:lane:both=yes` => `parking:lane:both=parallel`

CC: @zzptichka @heatshear 